### PR TITLE
Add legend to plot_centroids

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -1,5 +1,5 @@
-library(viridis)
-library(graphics)
+# library(viridis)
+# library(graphics)
 
 
 #' Plotting centroids
@@ -11,42 +11,68 @@ library(graphics)
 #'		vector of colors
 #' @param smooth boolean, optional, default: FALSE
 #'  Whether to smooth the centroids or not.
-#' @param margins vector containing the margins between
+#' @param mar vector of margins to set the space around each plot (see \code{\link{par}})
+#' @param legend boolean whether to include a legend (default:TRUE)
+#' @param legendArgs list of arguments to be passed to legend command (if \code{legend=TRUE})
+#' @param ... arguments to be passed to the individual plot commands
+#'  (Will be sent to all plot commands)
+#' @param simpleY boolean, if true, will minimize the annotation of the y axis to 
+#'  only label the axis in the exterior plots (the x-axis is always assumed to be the 
+#'  same across all plots and will always be simplified)
+#' @param mfrow a vector of integers of length 2 defining the grid of plots to be created (see \code{\link{par}}). If missing, the function will set a value.
+
 #' @export
-plot_centroids = function(centroids, splines_model, colors=NULL, smooth=FALSE, mar=c(1.0, 1.0, 1.0, 1.0)){
+plot_centroids = function(centroids, splines_model, colors=NULL, smooth=FALSE, legend=TRUE, legendArgs=NULL,simpleY=TRUE, mar=c(2.5, 2.5, 3.0, 1.0),mfrow=NULL,...){
     n_centroids = dim(centroids)[1]
-    if(n_centroids <= 3){
-        graphics::par(
-	    mfrow=c(n_centroids, 1),
-            mar=c(1.0, 1.0, 1.0, 1.0))
-    }else if(n_centroids <= 6){
-        n_col = ceiling(n_centroids / 2)
-        graphics::par(
-	    mfrow=c(n_col, 2),
-            mar=c(1.0, 1.0, 1.0, 1.0))
-    }else if(n_centroids <= 12){
-        ncol = ceiling(n_centroids / 3)
-        graphics::par(
-	    mfrow=c(ncol, 3),
-            mar=c(1.0, 1.0, 1.0, 1.0))
-    }else{
-        nrow = round(n_centroids ** 0.5)
-        ncol = ceiling(n_centroids / nrow)
-        graphics::par(
-	    mfrow=c(ncol, nrow),
-            mar=c(1.0, 1.0, 1.0, 1.0))
+    n_plots<-if(legend) n_centroids+1 else n_centroids
+    if(!is.null(mfrow)){
+        if(mfrow[1]*mfrow[2] < n_plots) stop(sprintf("Invalid value for argument mfrow. Should result in grid for at least %s plots (including a plot for the legend, if legend=TRUE)", n_plots))
     }
+    else{
+        if(n_plots <= 3){ 
+            mfrow<-c(n_plots, 1)
+        }else if(n_plots <= 6){
+            mfrow=c(ceiling(n_plots / 2), 2)
+        }else if(n_plots <= 12){
+            mfrow=c(ceiling(n_plots / 3), 3)
+        }else{
+            nrow = round(n_plots ** 0.5)
+            ncol = ceiling(n_plots / nrow)
+            mfrow=c(ncol, nrow)
+        }        
+    }
+    graphics::par(mfrow=mfrow, mar=mar)
+    bottomPlots<-seq(to=n_centroids,by=1,length=mfrow[2])
+    sidePlots<-seq(from=1,to=n_centroids,by=mfrow[2])
 
     name_centroids = row.names(centroids)
     name_centroid = NULL
+    
+    if(is.null(colors)){
+        groups = levels(meta$Group)
+        colors = viridis::viridis(length(groups))
+        names(colors) = groups
+    }
     for(i in 1:n_centroids){
-	if(!is.null(name_centroids)){
-	    name_centroid = name_centroids[i]
-	}
+    	if(!is.null(name_centroids)){
+    	    name_centroid = name_centroids[i]
+    	}
         plot_centroid_individual(as.vector(centroids[i, ]),
 				 splines_model, colors=colors,
 				 smooth=smooth,
-				 title=name_centroid)
+				 title=name_centroid,
+                 xaxt=if(!i %in% bottomPlots) "n" else "s",
+                 yaxt=if(!i %in% sidePlots & simpleY) "n" else "s", ...
+                 )
+        if(!i %in% bottomPlots) axis(1, labels=FALSE)
+        if(!i %in% sidePlots & simpleY) axis(2, labels=FALSE)
+        
+    }
+    if(legend){
+        plot.new()
+        plot.window(xlim=c(0,1), ylim=c(0,1), bty="n",xaxt="n",yaxt="n")
+        do.call("legend",c(list(x="center",
+            legend=names(colors),fill=colors,bty="n"),legendArgs))
     }
 }
 
@@ -60,14 +86,15 @@ plot_centroids = function(centroids, splines_model, colors=NULL, smooth=FALSE, m
 #'		vector of colors
 #' @param smooth boolean, optional, default: FALSE
 #'  Whether to smooth the centroids or not.
+#' @param ... arguments passed to plot_centroids
 #' @export
-plot_genes = function(data, splines_model, colors=NULL, smooth=FALSE){
-    plot_centroids(data, splines_model, colors=colors, smooth=smooth)
+plot_genes = function(data, splines_model, colors=NULL, smooth=FALSE,...){
+    plot_centroids(data, splines_model, colors=colors, smooth=smooth,simpleY=FALSE,...)
 }
 
 
-plot_centroid_individual = function(centroid, splines_model, colors=NULL, smooth=FALSE,
-				    title=NULL){
+plot_centroid_individual = function(centroid, splines_model, colors, smooth=FALSE,
+				    title=NULL,...){
     meta = splines_model$meta
     groups = levels(meta$Group)
 
@@ -77,11 +104,7 @@ plot_centroid_individual = function(centroid, splines_model, colors=NULL, smooth
         centroid = t(as.matrix(centroid))
     }
 
-    graphics::plot(xrange, yrange, type="n", main=title)
-    if(is.null(colors)){
-        colors = viridis::viridis(length(groups))
-	names(colors) = groups
-    }
+    graphics::plot(xrange, yrange, type="n", main=title,...)
     if(smooth){
 	# FIXME this is supposed to be on the fitted lines, but I'm not able
 	# to get this to work fine in R.

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -60,7 +60,7 @@ plot_centroids = function(centroids, splines_model, colors=NULL, smooth=FALSE, l
         plot_centroid_individual(as.vector(centroids[i, ]),
 				 splines_model, colors=colors,
 				 smooth=smooth,
-				 title=name_centroid,
+				 main=name_centroid,
                  xaxt=if(!i %in% bottomPlots) "n" else "s",
                  yaxt=if(!i %in% sidePlots & simpleY) "n" else "s", ...
                  )
@@ -93,8 +93,7 @@ plot_genes = function(data, splines_model, colors=NULL, smooth=FALSE,...){
 }
 
 
-plot_centroid_individual = function(centroid, splines_model, colors, smooth=FALSE,
-				    title=NULL,...){
+plot_centroid_individual = function(centroid, splines_model, colors, smooth=FALSE,...){
     meta = splines_model$meta
     groups = levels(meta$Group)
 
@@ -104,7 +103,7 @@ plot_centroid_individual = function(centroid, splines_model, colors, smooth=FALS
         centroid = t(as.matrix(centroid))
     }
 
-    graphics::plot(xrange, yrange, type="n", main=title,...)
+    graphics::plot(xrange, yrange, type="n", ...)
     if(smooth){
 	# FIXME this is supposed to be on the fitted lines, but I'm not able
 	# to get this to work fine in R.

--- a/tests/testthat/test-visualization.R
+++ b/tests/testthat/test-visualization.R
@@ -25,5 +25,7 @@ test_that("visualization::plot_centroids", {
 
     expect_silent(plot_centroids(data, splines_model))
     expect_silent(plot_centroids(data, splines_model, smooth=TRUE))
+    expect_error(plot_centroids(data, splines_model, smooth=TRUE, mfrow=c(1,1)))
+    expect_silent(plot_centroids(data, splines_model, smooth=TRUE, mfrow=c(1,1), legend=FALSE))
 
 })


### PR DESCRIPTION
I've added option for legend in plot_centroids, as well as not replotting the x-axis (and optionally not replotting the y-axis; plot_genes does not pick this option). Might be good to make the x-axis optional too. 

Also added `...` to functions to allow users to pass plotting arguments, and allow user to define the mfrow command.