### PR TITLE
fix plot_splines_data for centroid plotting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: moanin
 Title: An R Package for Time Course RNASeq Data Analysis
-Version: 0.99.0-901
+Version: 0.99.0-902
 Authors@R: c(person("Elizabeth", "Purdom", email="epurdom@stat.berkeley.edu",
                     role=c("aut"),
                     comment=c("orcid"="https://orcid.org/0000-0001-9455-7990")),

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -19,6 +19,10 @@ setGeneric("plot_splines_data",
 #'  minimize the annotation of the y axis to only label the axis in the exterior
 #'  plots (the x-axis is always assumed to be the same across all plots and will
 #'  always be simplified)
+#'@param scale_centroid determines whether the centroid data given in
+#'  \code{centroid} should be rescaled to match that of the data
+#'  (\code{"toData"}), or the data scaled to match that of centroid
+#'  (\code{"toCentroid"}), or simply plotted as is (\code{"none"}).
 #'@param subset_conditions list if provided, only plots the subset of conditions
 #'  provided. Else, plots all conditions
 #'@param centroid numeric vector (or matrix of 1 row) with data to use to fit

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -15,15 +15,17 @@ setGeneric("plot_splines_data",
 #'@param legend boolean whether to include a legend (default:TRUE)
 #'@param legendArgs list of arguments to be passed to legend command (if
 #'  \code{legend=TRUE})
-#'@param simpleY boolean, if true, will minimize the annotation of the y axis to
-#'  only label the axis in the exterior plots (the x-axis is always assumed to
-#'  be the same across all plots and will always be simplified)
+#'@param simpleY boolean, if true, will plot all genes on same y-axis and
+#'  minimize the annotation of the y axis to only label the axis in the exterior
+#'  plots (the x-axis is always assumed to be the same across all plots and will
+#'  always be simplified)
 #'@param subset_conditions list if provided, only plots the subset of conditions
 #'  provided. Else, plots all conditions
 #'@param centroid numeric vector (or matrix of 1 row) with data to use to fit
 #'  the splines. If \code{NULL}, the splines plotted will be from the data.
 #'@param subset_data list if provided, only plots the subset of data (ie, the
-#'  rows) provided. Can be any valid vector for subsetting a matrix. See details.
+#'  rows) provided. Can be any valid vector for subsetting a matrix. See
+#'  details.
 #'@param mfrow a vector of integers of length 2 defining the grid of plots to be
 #'  created (see \code{\link{par}}). If missing, the function will set a value.
 #'@param addToPlot A function that will be called after the plotting, allowing
@@ -31,7 +33,8 @@ setGeneric("plot_splines_data",
 #'@param ... arguments to be passed to the individual plot commands (Will be
 #'  sent to all plot commands)
 #' @details If \code{data} is NULL, the data plotted will be from
-#'   \code{assay(object)}, after log-transformation if \code{log_transform(object)=TRUE}. 
+#'   \code{assay(object)}, after log-transformation if
+#'   \code{log_transform(object)=TRUE}.
 #' @details If \code{centroid} is missing, then splines will be estimated (per
 #'   group) for the the data in \code{data} -- separately for each row of
 #'   \code{data}. If \code{centroid} is provided, this data will be used to plot
@@ -49,30 +52,33 @@ setGeneric("plot_splines_data",
 #'    degrees_of_freedom=6)
 #'
 #' # The moanin model contains all the information for plotting purposes. The
-#' # plot_splines_function will automatically fit the splines from the
+#' # plot_splines_data will automatically fit the splines from the
 #' # information contained in the moanin model
 #' genes = c("NM_001042489", "NM_008725")
 #' plot_splines_data(moanin, subset_data=genes,
 #' mfrow=c(2, 2))
+#' # By default, same axis for all genes. Can change with 'simpleY=FALSE'
+#' plot_splines_data(moanin, subset_data=genes,
+#'    smooth=TRUE, mfrow=c(2,2), simpleY=FALSE)   
 #'
 #' # The splines can also be smoothed
 #' plot_splines_data(moanin, subset_data=genes,
 #'    smooth=TRUE, mfrow=c(2, 2))
-#'    
-#' # You can provide different data on same subjects,
+#' # You can provide different data (on same subjects),
 #' # instead of data in moanin object
 #' # (in which case moanin just provides grouping information)
 #' plot_splines_data(moanin, data=1/assay(moanin), subset_data=genes,
 #'    smooth=TRUE, mfrow=c(2, 2))
 #'    
-#' # You can also provide data for fitting splines, 
-#' # but plot the data in Moanin object
-#' # This is helpful for overlaying centroids or predicted data
+#' # You can also provide data to use for fitting splines to argument  
+#' # "centroid". This is helpful for overlaying centroids or predicted data
 #' # Here we do a silly example, just to demonstrate syntax, 
 #' # where we use the data from the first gene as our centroid to fit a
 #' # spline estimate, but plot data from genes 3-4
 #' plot_splines_data(moanin, centroid=assay(moanin[1,]), subset_data=3:4,
 #'    smooth=TRUE, mfrow=c(2,2))
+
+
 #' @export
 #' @name plot_splines_data
 #' @aliases plot_splines_data,Moanin,matrix-method
@@ -85,9 +91,10 @@ setMethod("plot_splines_data",c("Moanin","matrix"),
                 subset_conditions=NULL,
                 subset_data=NULL,
                 simpleY=TRUE, centroid=NULL,
+                scale_centroid=c("toData","toCentroid","none"),
                 mar=c(2.5, 2.5, 3.0, 1.0),
-                mfrow=NULL, addToPlot=NULL, ...){
-    
+                mfrow=NULL, addToPlot=NULL, ylab="", xlab="Time",...){
+    scale_centroid = match.arg(scale_centroid)
     check_data_meta(data=data,object=object)
     if(!is.null(centroid)){
         check_data_meta(data=centroid,object=object)
@@ -145,20 +152,49 @@ setMethod("plot_splines_data",c("Moanin","matrix"),
     
     plot_names = row.names(data)
     name = NULL 
+    if(!is.null(centroid)){
+        if(scale_centroid=="toData"){
+            centroid = align_data_onto_centroid(data, centroid, 
+                                                returnType="centroid")
+        }
+        if(scale_centroid=="toCentroid"){
+            data = align_data_onto_centroid(data, centroid, returnType="data")
+        }
+        if(scale_centroid %in% c("toCentroid","none")){
+            #make it a matrix
+            centroid = matrix(centroid, nrow=nrow(data),ncol=length(centroid),
+                              byrow=TRUE)
+        }
+    }
     
+    ## Fix up the y-axis range
+    if("ylim" %in% names(list(...))){
+        ylim = list(...)$ylim
+    }
+    else ylim = NULL
+    if(simpleY & is.null(ylim)){
+        # use same y-axis range
+        yrange = range(data)
+    }
+    else{
+        if(!is.null(ylim)) yrange = ylim
+        else yrange = NULL
+    }
+
     # Now plot the different data
     for(i in seq_len(n_observations)){
         if(!is.null(plot_names)){
             name = plot_names[i]
         }
         plot_centroid_individual(
-            data=data[i, ], centroid=centroid,
+            data=data[i, ], centroid=if(is.null(centroid)) centroid else centroid[i,],
             object[i,], colors=colors,
             smooth=smooth,
             subset_conditions=subset_conditions,
-            main=name, 
+            main=name, yrange=yrange,
             xaxt=if(!i %in% bottomPlots) "n" else "s",
-            yaxt=if(!i %in% sidePlots & simpleY) "n" else "s", ...)
+            yaxt=if(!i %in% sidePlots & simpleY) "n" else "s", 
+            xlab=xlab,ylab=ylab,...)
         
         if(is.function(addToPlot)){
             addToPlot()
@@ -235,7 +271,7 @@ setMethod("plot_splines_data",c("Moanin","missing"),
 # moanin_model will separate them into groups...
 plot_centroid_individual = function(data, centroid, moanin_model,
                                     colors, smooth=FALSE, 
-                                    subset_conditions=NULL,...){
+                                    subset_conditions=NULL,yrange=NULL,...){
     if(is.null(data)){
         data=as.vector(get_log_data(moanin_model))
     }
@@ -260,9 +296,11 @@ plot_centroid_individual = function(data, centroid, moanin_model,
     xrange = range(time_variable(moanin_model))
     if(inherits(centroid,"DataFrame")) centroid<-as.matrix(centroid)
     if(is.null(dim(centroid))) centroid = t(as.matrix(centroid))
-    yrangeCentroid = range(centroid[, group_variable(moanin_model) %in% groups])
-    yrangeData = range(data[group_variable(moanin_model) %in% groups])
-    yrange = range(c(yrangeCentroid,yrangeData))
+    if(is.null(yrange)){
+        yrangeCentroid = range(centroid[, group_variable(moanin_model) %in% groups])
+        yrangeData = range(data[group_variable(moanin_model) %in% groups])
+        yrange = range(c(yrangeCentroid,yrangeData))
+    }
     graphics::plot(xrange, yrange, type="n", ...)
     if(smooth){
         # FIXME this is supposed to be on the fitted lines, but I'm not able

--- a/man/plot_splines_data.Rd
+++ b/man/plot_splines_data.Rd
@@ -72,6 +72,11 @@ always be simplified)}
 \item{centroid}{numeric vector (or matrix of 1 row) with data to use to fit
 the splines. If \code{NULL}, the splines plotted will be from the data.}
 
+\item{scale_centroid}{determines whether the centroid data given in
+\code{centroid} should be rescaled to match that of the data
+(\code{"toData"}), or the data scaled to match that of centroid
+(\code{"toCentroid"}), or simply plotted as is (\code{"none"}).}
+
 \item{mar}{vector of margins to set the space around each plot (see
 \code{\link{par}})}
 

--- a/man/plot_splines_data.Rd
+++ b/man/plot_splines_data.Rd
@@ -20,9 +20,12 @@
   subset_data = NULL,
   simpleY = TRUE,
   centroid = NULL,
+  scale_centroid = c("toData", "toCentroid", "none"),
   mar = c(2.5, 2.5, 3, 1),
   mfrow = NULL,
   addToPlot = NULL,
+  ylab = "",
+  xlab = "Time",
   ...
 )
 
@@ -58,11 +61,13 @@ centroids or not.}
 provided. Else, plots all conditions}
 
 \item{subset_data}{list if provided, only plots the subset of data (ie, the
-rows) provided. Can be any valid vector for subsetting a matrix. See details.}
+rows) provided. Can be any valid vector for subsetting a matrix. See
+details.}
 
-\item{simpleY}{boolean, if true, will minimize the annotation of the y axis to
-only label the axis in the exterior plots (the x-axis is always assumed to
-be the same across all plots and will always be simplified)}
+\item{simpleY}{boolean, if true, will plot all genes on same y-axis and
+minimize the annotation of the y axis to only label the axis in the exterior
+plots (the x-axis is always assumed to be the same across all plots and will
+always be simplified)}
 
 \item{centroid}{numeric vector (or matrix of 1 row) with data to use to fit
 the splines. If \code{NULL}, the splines plotted will be from the data.}
@@ -87,7 +92,8 @@ Plotting splines
 }
 \details{
 If \code{data} is NULL, the data plotted will be from
-  \code{assay(object)}, after log-transformation if \code{log_transform(object)=TRUE}.
+  \code{assay(object)}, after log-transformation if
+  \code{log_transform(object)=TRUE}.
 
 If \code{centroid} is missing, then splines will be estimated (per
   group) for the the data in \code{data} -- separately for each row of
@@ -107,25 +113,26 @@ moanin = create_moanin_model(data=testData,meta=testMeta,
    degrees_of_freedom=6)
 
 # The moanin model contains all the information for plotting purposes. The
-# plot_splines_function will automatically fit the splines from the
+# plot_splines_data will automatically fit the splines from the
 # information contained in the moanin model
 genes = c("NM_001042489", "NM_008725")
 plot_splines_data(moanin, subset_data=genes,
 mfrow=c(2, 2))
+# By default, same axis for all genes. Can change with 'simpleY=FALSE'
+plot_splines_data(moanin, subset_data=genes,
+   smooth=TRUE, mfrow=c(2,2), simpleY=FALSE)   
 
 # The splines can also be smoothed
 plot_splines_data(moanin, subset_data=genes,
    smooth=TRUE, mfrow=c(2, 2))
-   
-# You can provide different data on same subjects,
+# You can provide different data (on same subjects),
 # instead of data in moanin object
 # (in which case moanin just provides grouping information)
 plot_splines_data(moanin, data=1/assay(moanin), subset_data=genes,
    smooth=TRUE, mfrow=c(2, 2))
    
-# You can also provide data for fitting splines, 
-# but plot the data in Moanin object
-# This is helpful for overlaying centroids or predicted data
+# You can also provide data to use for fitting splines to argument  
+# "centroid". This is helpful for overlaying centroids or predicted data
 # Here we do a silly example, just to demonstrate syntax, 
 # where we use the data from the first gene as our centroid to fit a
 # spline estimate, but plot data from genes 3-4

--- a/tests/testthat/test-splines.R
+++ b/tests/testthat/test-splines.R
@@ -18,23 +18,29 @@ test_that("splines:align_data_onto_centroid", {
     n_genes = 5
     centroid = runif(n_samples)
 
-    shift = runif(n_genes)
-    scale = 1 + runif(n_genes)
-
+    ## don't do anything, just make data equal to centroid.
+    ## (Shouldn't do anything)
     data = rep(centroid, each=n_genes)
     dim(data) = c(n_genes, n_samples)
     expect_equal(data, align_data_onto_centroid(data, centroid))
-
+    expect_equal(data, align_data_onto_centroid(data, centroid, returnType="centroid"))
+    
     # Ok, now let's make this a bit more complicated.
-    scale = rep(scale, times=n_samples)
-    dim(scale) = dim(data)
-    shift = rep(shift, times=n_samples)
-    dim(shift) = dim(data)
+    shift_param = runif(n_genes)
+    scale_param = 1 + runif(n_genes)
+    scale_param = rep(scale_param, times=n_samples)
+    dim(scale_param) = dim(data)
+    shift_param = rep(shift_param, times=n_samples)
+    dim(shift_param) = dim(data)
 
-    shifted_scaled_data = scale * data + shift
-    shifted_scaled_centroid = scale * centroid + shift
+    shifted_scaled_data = scale_param * data + shift_param
+    shifted_scaled_centroid = scale_param * centroid + shift_param
     expect_equal(data,
 		 align_data_onto_centroid(shifted_scaled_data, centroid))
+    expect_equal(shifted_scaled_data,
+                 align_data_onto_centroid(shifted_scaled_data, centroid,returnType="centroid"))
+
+    # Check error checking works
     expect_error(align_data_onto_centroid(data[, 1:10], centroid))
 })
 


### PR DESCRIPTION
Rescales centroid to match scale of data in `plot_splines_data`. Doesn't currently rescale by group, but only across all of the data/centroid.